### PR TITLE
Add README with project management summary and links to OctoAcme docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,43 @@
+# OctoAcme Project Management Documentation
+
+Welcome to the OctoAcme Project Management Docs repository. This collection outlines our standards, processes, and best practices for project execution at OctoAcme.
+
+## Project Management Processes Summary
+
+OctoAcme employs a structured, lifecycle-based approach to project management that prioritizes customer value, iterative delivery, and clear ownership. Projects move through five phases: **Initiation**, **Planning**, **Execution**, **Release**, and **Retrospective**.
+
+- **Initiation & Planning**: Begin with a Project One-pager outlining the problem, success metrics, stakeholders, and resource needs. Planning follows, breaking work into shippable increments, defining acceptance criteria, and mapping dependencies.
+- **Execution & Tracking**: The execution phase emphasizes daily standups, weekly syncs, and pull request workflows managed in GitHub Projects. Teams use automated tests, linting, small PRs, and approval policies to ensure disciplined execution and transparency.
+- **Quality Assurance**: Quality is integrated throughout execution, including unit, integration, and end-to-end smoke tests, CI-based security scanning, and manual QA when required.
+- **Release & Retrospective**: Releases follow standardized checklists and smoke testing with clear rollback procedures, and retrospectives are conducted after each milestone to drive continuous improvement and reduce risk.
+
+### Roles & Communication
+
+There are three core roles: **Developers** (build and ensure technical quality), **Product Managers** (define business and customer value, prioritize work), and **Project Managers** (coordinate timelines, risks, and stakeholder alignment). Daily standups, weekly delivery syncs, and monthly stakeholder updates foster transparency. Risks and blockers are tracked in a central register, with three-level escalation for resolution.
+
+**Guiding Principles**: Customer-first, iterative delivery, clear ownership, data-informed decisions, and psychological safety for team learning.
+
+---
+
+## Documentation Index
+
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution and Tracking](octoacme-execution-and-tracking.md)
+- [Risks and Communication](octoacme-risks-and-communication.md)
+- [Release and Deployment](octoacme-release-and-deployment.md)
+- [Retrospective and Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](octoacme-roles-and-personas.md)
+
+---
+
+## Quick Start
+
+1. Read the [Project Management Overview](octoacme-project-management-overview.md)
+2. Review [Roles and Personas](octoacme-roles-and-personas.md)
+3. Use other guides as your project progresses
+
+To suggest improvements, use the [Add Content to Project Management Process Docs](../.github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml) template.
+
+_Last updated: February 2026 – Maintained by the OctoAcme Program Management Team_


### PR DESCRIPTION
This pull request adds a README.md file under the docs/ folder. The README gives a brief but comprehensive summary of OctoAcme's project management processes—including workflows, roles, communication, and quality practices—and provides a centralized index with links to all process documents.

Closes #2
